### PR TITLE
fix: do not use hardcoded `AlwaysSample` option

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -113,7 +113,6 @@ func (p *Plugin) Init(cfg Configurer, log Logger) error { //nolint:gocyclo
 	}
 
 	p.tracer = sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(newResource(p.cfg.Resource, cfg.RRVersion())),
 	)
@@ -138,19 +137,15 @@ func (p *Plugin) Serve() chan error {
 	return make(chan error, 1)
 }
 
-func (p *Plugin) Stop(context.Context) error {
+func (p *Plugin) Stop(ctx context.Context) error {
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#forceflush
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-	defer cancel()
 	err := p.tracer.ForceFlush(ctx)
 	if err != nil {
 		return err
 	}
 
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown
-	ctx2, cancel := context.WithTimeout(context.Background(), time.Second*30)
-	defer cancel()
-	err = p.tracer.Shutdown(ctx2)
+	err = p.tracer.Shutdown(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1918

## Description of Changes

- Use OTEL defaults instead of hard-coded AlwaysSample.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved context handling in the application's operation functions for enhanced performance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->