### PR TITLE
chore: do not set Endpoint and Headers for grpc

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -187,8 +187,14 @@ func grpcOptions(cfg *Config) []otlptracegrpc.Option {
 		options = append(options, otlptracegrpc.WithCompressor("gzip"))
 	}
 
-	options = append(options, otlptracegrpc.WithEndpoint(cfg.Endpoint))
-	options = append(options, otlptracegrpc.WithHeaders(cfg.Headers))
+	// if unset, OTEL will use the default one automatically
+	if cfg.Endpoint != "" {
+		options = append(options, otlptracegrpc.WithEndpoint(cfg.Endpoint))
+	}
+
+	if len(cfg.Headers) > 0 {
+		options = append(options, otlptracegrpc.WithHeaders(cfg.Headers))
+	}
 
 	return options
 }


### PR DESCRIPTION


# Reason for This PR

As discussed in https://github.com/roadrunner-server/roadrunner/issues/1848, otel packages can read a standardised set of environments, but only if values have not been overridden. In [the previous PR addressing this](https://github.com/roadrunner-server/otel/pull/60), only the http client was updated. This PR updates the grpc client to match.

## Description of Changes

Only set (and thus override) the endpoint and header options if they're actually set in the config.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced conditional logic for configuring gRPC options, allowing for more flexible and meaningful configurations.
  
- **Bug Fixes**
	- Prevented the addition of default or empty values to gRPC options, reducing potential misconfigurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->