### PR TITLE
feature: support standard `OTEL` exporter protocol environment variables

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package otel
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -80,7 +81,11 @@ func (c *Config) InitDefault(log *zap.Logger) {
 	switch c.Client {
 	case grpcClient:
 	case httpClient:
+	case "":
+		c.Client = httpClient
+		setClientFromEnv(&c.Client, log)
 	default:
+		log.Warn("unknown exporter client", zap.String("client", string(c.Client)))
 		c.Client = httpClient
 	}
 
@@ -110,5 +115,26 @@ func (c *Config) InitDefault(log *zap.Logger) {
 
 	if c.Resource.ServiceNamespaceKey == "" {
 		c.Resource.ServiceNamespaceKey = fmt.Sprintf("RoadRunner-%s", uuid.NewString())
+	}
+}
+
+func setClientFromEnv(client *Client, log *zap.Logger) {
+	// https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specify-protocol
+	exporterEnv := "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+	exporterVal := os.Getenv(exporterEnv)
+	if exporterVal == "" {
+		exporterEnv = "OTEL_EXPORTER_OTLP_PROTOCOL"
+		exporterVal = os.Getenv(exporterEnv)
+	}
+	switch exporterVal {
+	case "":
+	case "grpc":
+		*client = grpcClient
+	case "http/protobuf":
+		*client = httpClient
+	case "http/json":
+		log.Warn("unsupported exporter protocol", zap.String("env.name", exporterEnv), zap.String("env.value", exporterVal))
+	default:
+		log.Warn("unknown exporter protocol", zap.String("env.name", exporterEnv), zap.String("env.value", exporterVal))
 	}
 }

--- a/config.go
+++ b/config.go
@@ -79,8 +79,8 @@ func (c *Config) InitDefault(log *zap.Logger) {
 	}
 
 	switch c.Client {
-	case grpcClient:
-	case httpClient:
+	case grpcClient, httpClient:
+		// ok value, do nothing
 	case "":
 		c.Client = httpClient
 		setClientFromEnv(&c.Client, log)
@@ -128,6 +128,7 @@ func setClientFromEnv(client *Client, log *zap.Logger) {
 	}
 	switch exporterVal {
 	case "":
+		// env var not set, do not change the client
 	case "grpc":
 		*client = grpcClient
 	case "http/protobuf":


### PR DESCRIPTION
# Reason for This PR

OpenTelemetry has some standardised environment variables for choosing which client to use: https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specify-protocol

In Go, these can be consumed using the 1st-party package https://pkg.go.dev/go.opentelemetry.io/contrib/exporters/autoexport, but because this otel plugin already does some custom stuff, I've opted to try reimplementing the semantics of the spec in the plugin.

## Description of Changes

In case the client is unset in the config, check the standardised environment variables `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` and `OTEL_EXPORTER_OTLP_PROTOCOL` for a configured protocol.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced configuration flexibility by allowing users to dynamically set the client protocol based on environment variables for improved adaptability to different runtime environments.
  
- **Bug Fixes**
  - Added logging for unrecognized environment variable values to improve error handling and user awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->