### PR TITLE
chore: Adjust default naming logic for otel resources

### DIFF
--- a/config.go
+++ b/config.go
@@ -94,7 +94,7 @@ func (c *Config) InitDefault(log *zap.Logger) {
 	fillValue(&c.Resource.ServiceNameKey, c.ServiceName, envAttrs, semconv.ServiceNameKey, "RoadRunner")
 	fillValue(&c.Resource.ServiceVersionKey, c.ServiceVersion, envAttrs, semconv.ServiceVersionKey, "1.0.0")
 	fillValue(&c.Resource.ServiceInstanceIDKey, "", envAttrs, semconv.ServiceInstanceIDKey, uuid.NewString())
-	fillValue(&c.Resource.ServiceNamespaceKey, "", envAttrs, semconv.ServiceNamespaceKey, fmt.Sprintf("RoadRunner-%s", uuid.NewString()))
+	fillValue(&c.Resource.ServiceNamespaceKey, "", envAttrs, semconv.ServiceNamespaceKey, fmt.Sprintf("%s-%s", c.Resource.ServiceNameKey, uuid.NewString()))
 }
 
 func setClientFromEnv(client *Client, log *zap.Logger) {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	go.opentelemetry.io/otel/exporters/zipkin v1.31.0
 	go.opentelemetry.io/otel/sdk v1.31.0
 	go.opentelemetry.io/otel/trace v1.31.0
-	go.temporal.io/sdk v1.29.1
+	go.temporal.io/sdk v1.30.0
 	go.temporal.io/sdk/contrib/opentelemetry v0.6.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.67.1

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeX
 go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
 go.temporal.io/api v1.40.0 h1:rH3HvUUCFr0oecQTBW5tI6DdDQsX2Xb6OFVgt/bvLto=
 go.temporal.io/api v1.40.0/go.mod h1:1WwYUMo6lao8yl0371xWUm13paHExN5ATYT/B7QtFis=
-go.temporal.io/sdk v1.29.1 h1:y+sUMbUhTU9rj50mwIZAPmcXCtgUdOWS9xHDYRYSgZ0=
-go.temporal.io/sdk v1.29.1/go.mod h1:kp//DRvn3CqQVBCtjL51Oicp9wrZYB2s6row1UgzcKQ=
+go.temporal.io/sdk v1.30.0 h1:7jzSFZYk+tQ2kIYEP+dvrM7AW9EsCEP52JHCjVGuwbI=
+go.temporal.io/sdk v1.30.0/go.mod h1:Pv45F/fVDgWKx+jhix5t/dGgqROVaI+VjPLd3CHWqq0=
 go.temporal.io/sdk/contrib/opentelemetry v0.6.0 h1:rNBArDj5iTUkcMwKocUShoAW59o6HdS7Nq4CTp4ldj8=
 go.temporal.io/sdk/contrib/opentelemetry v0.6.0/go.mod h1:Lem8VrE2ks8P+FYcRM3UphPoBr+tfM3v/Kaf0qStzSg=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/schema.json
+++ b/schema.json
@@ -28,7 +28,7 @@
         "service_namespace": {
           "type": "string",
           "description": "The namespace of the service.",
-          "default": "RoadRunner-<uuid>",
+          "default": "<service_name>-<uuid>",
           "minLength": 1
         },
         "service_instance_id": {


### PR DESCRIPTION
# Reason for This PR

The default naming logic is inconsistent here, as it depends on deprecated fields. If you don't use those deprecate fields, your service name will be empty.

This also changes the default name of the service namespace to include the service name, instead of defaulting to roadrunner (which is still the default service name key).

`service_name` and `service_version` are both deprecated at the plugin level.

## Description of Changes

`[Author TODO: add description of changes.]`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the construction of the `service_namespace` to incorporate the service name, enhancing clarity and organization.

- **Bug Fixes**
	- Deprecated `service_name` and `service_version` properties, directing users to utilize `resource.service_name` and `resource.service_version` for improved schema structure.

- **Documentation**
	- Updated schema documentation to reflect changes in property usage and deprecation notices, promoting a more hierarchical approach to service metadata.

- **Chores**
	- Updated the `go.temporal.io/sdk` dependency version from `v1.29.1` to `v1.30.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->